### PR TITLE
Correct typos in lectures 4 to 11

### DIFF
--- a/lecture10/notes.md
+++ b/lecture10/notes.md
@@ -30,7 +30,7 @@ Under some assumptions on the type of noise, we saw that we can approximate the 
 If $x^\star$ is an asymptotically stable equilibrium of the ODE, then $x^{(k)} \to x^\star$ with probability one. 
 
 
-# TD(0) witih linear function approximation
+# TD(0) with linear function approximation
 \begin{align*}
 w^{(t+1)} = w^{(t)} + \eta_t \underbrace{\underbrace{\left(r_t + \gamma v\left(s_{t+1}; w^{(t)}\right) - v\left(s_t; w^{(t)}\right) \right)}_{\delta_t} \phi_t}_{y_t}\enspace .
 \end{align*}
@@ -51,7 +51,7 @@ Here $\phi_t \triangleq \phi(S_t)$, $\phi_{t+1} \triangleq \phi(S_{t+1})$, $R_t 
 
 The above expectation is linear function of $\bar{w}^{(k)}$, therefore, we can also write it in matrix form as: 
 \begin{align*}
-\bar{w}^{(k)} &=  \bar{w}^{(k)} + \eta_k \mathbb{E}\left[  \left(R_t + \phi_t^\top \bar{w}^{(k)} - \gamma \phi_{t+1}^\top \bar{w}^{(k)}\right) \phi_t \right]\\
+\bar{w}^{(k+1)} &=  \bar{w}^{(k)} + \eta_k \mathbb{E}\left[  \left(R_t + \phi_t^\top \bar{w}^{(k)} - \gamma \phi_{t+1}^\top \bar{w}^{(k)}\right) \phi_t \right]\\
 &=\bar{w}^{(k)} + \eta_k \left(\Phi^\top X r_d - \Phi^\top X \left(I - \gamma P_d\right) \Phi \bar{w}^{(k)} \right) \enspace .
 \end{align*}
 
@@ -84,7 +84,7 @@ is negative definite.
 Instead of the above two analysis methods, we are instead going to leverage an operator theoretic perspective on our problem. 
 Consider again the deterministic iterates: 
 \begin{align*}
-\bar{w}^{(k)} &=\bar{w}^{(k)} + \eta_k \left(\Phi^\top X r_d - \Phi^\top X \left(I - \gamma P_d\right) \Phi \bar{w}^{(k)} \right) \enspace .
+\bar{w}^{(k+1)} &=\bar{w}^{(k)} + \eta_k \left(\Phi^\top X r_d - \Phi^\top X \left(I - \gamma P_d\right) \Phi \bar{w}^{(k)} \right) \enspace .
 \end{align*}
 
 This can be seen as an instance of Richardson iteration for solving the linear system of equations: 
@@ -124,7 +124,7 @@ We made the assumption that $\Phi$ is full rank, which means that the set of min
 
 Let $T$ be an operator projecting onto the space $\mathcal{B}$ spanned by the columns of $\Phi$ (ie. any vector in that space can be written as a unique linear combination of the vectors in the basis). 
 
-The meaning of $T$ being a projection is that that is given any $v\in \mathbb{R}^{|\mathcal{S}|}$, $Tv$ returns the unique vector from $\mathcal{B}$ that minimizes $\|v - \hat{v}\|^2_x$ for any $\hat{v} \in \mathcal{B}$.
+The meaning of $T$ being a projection is that is given any $v\in \mathbb{R}^{|\mathcal{S}|}$, $Tv$ returns the unique vector from $\mathcal{B}$ that minimizes $\|v - \hat{v}\|^2_x$ for any $\hat{v} \in \mathcal{B}$.
 That is: 
 \begin{align*}
 Tv = \Phi \hat{w} \enspace \text{where}\enspace \hat{w} = \arg\min_{w \in \mathbb{R}^m} \| v - \Phi w\|^2_x
@@ -135,7 +135,7 @@ Tv = \Phi \hat{w} \enspace \text{where}\enspace \hat{w} = \arg\min_{w \in \mathb
 
 In our case, we want to project $L_d (\Phi w) \in \mathbb{R}^{|\mathcal{S}|}$. This means that we want to find a $\hat{w} \in \mathbb{R}^{m}$ such that:
 \begin{align*}
-\hat{w} = \arg\min_{w\in\mathbb{R}^m} \| \Phi w - (r_d + \gamma P \Phi \hat{w})\|^2_x
+\hat{w} = \arg\min_{w\in\mathbb{R}^m} \| \Phi w - (r_d + \gamma P_d \Phi \hat{w})\|^2_x
 \end{align*}
 
 The **projected policy evaluation operator** is the composition of the projection operator $T$ with the policy evaluation operator $L_d$. The corresponding fixed-point problem is then to find a $w \in \mathbb{R}^k$ such that: 
@@ -149,7 +149,7 @@ Wouldn't be nice if $T L_d$ were to be a contraction? We could then leverage Ban
 (Spoiler: yes, it can be). 
 
 Two notions to see before we get there:
-1. Projections are nonexpansives
+1. Projections are nonexpansive
 2. On-policy inequality
 
 1+2 + contractivity of $L_d$ will allows to build our proof. 
@@ -165,7 +165,7 @@ Projections are nonexpansive, this means that:
 Also, by the Pythagorean theorem:
 
 \begin{align*}
-\| Tv - Tu \|^2_x = \|T(v - u)\|^2_x \leq \|T(v -u)\|^2 + \| (I - T)(v - u) \|_x^2 = \|v - u\|^2_x
+\| Tv - Tu \|^2_x = \|T(v - u)\|^2_x \leq \|T(v -u)\|^2_x + \| (I - T)(v - u) \|_x^2 = \|v - u\|^2_x
 \end{align*}
 
 # 

--- a/lecture11/notes.md
+++ b/lecture11/notes.md
@@ -38,7 +38,7 @@ in which we have only noisy observations of $f(x)$.
 We then analyzed TD(0) using the ODE method and found that the mean iterates can be written as:
 
 \begin{align*}
-\bar{w}^{(k)} &=  \bar{w}^{(k)} + \eta_k \mathbb{E}\left[  \left(R_t + \phi_t^\top \bar{w}^{(k)} - \gamma \phi_{t+1}^\top \bar{w}^{(k)}\right) \phi_t \right]\\
+\bar{w}^{(k+1)} &=  \bar{w}^{(k)} + \eta_k \mathbb{E}\left[  \left(R_t + \phi_t^\top \bar{w}^{(k)} - \gamma \phi_{t+1}^\top \bar{w}^{(k)}\right) \phi_t \right]\\
 &=\bar{w}^{(k)} + \eta_k \left(\Phi^\top X r_d - \Phi^\top X \left(I - \gamma P_d\right) \Phi \bar{w}^{(k)} \right) \enspace .
 \end{align*}
 This lead us to study the corresponding linear ODE:
@@ -81,7 +81,7 @@ if $x$ is the stationary distribution of the Markov chain under $P$.
 
 # Error bound
 
-We can show that (prop 6.3.1) that the error can be bounded by: 
+We can show (prop 6.3.1) that the error can be bounded by: 
 
 \begin{align*}
 \|\underbrace{v_d}_{\mathclap{\text{true value function}}} - \Phi \overbrace{w^\star}^{\mathclap{\text{TD(0) solution}}}\|_x \leq \frac{1}{\sqrt{1 - \gamma^2}} \|v_d - \underbrace{T v_d}_{\mathclap{\text{projection of the true value function}}} \|_x \enspace .
@@ -94,7 +94,7 @@ We can control the bias using a variant of TD called TD($\lambda$). The idea is 
 \begin{align*}
 L^{(\lambda)}_d \triangleq (1 - \lambda) \sum_{k=0}^\infty \lambda^k L_d^{k+1} \enspace ,
 \end{align*} 
-with $\lambda \in [0, 1])$. Note that $L_d^k$ denotes the $k$-application of the *single*-step operator $L_d$, ie: $L^1 = L, L^2 = L L, ...$.
+with $\lambda \in [0, 1]$. Note that $L_d^k$ denotes the $k$-application of the *single*-step operator $L_d$, ie: $L^1 = L, L^2 = L L, ...$.
 We can then consider the fixed-point problem $L^{(\lambda)}_d v = v$ where:
 \begin{align*}
 L^{(\lambda)}_d v &= r^{(\lambda)}_d + \gamma P^{(\lambda)}_d v\\

--- a/lecture4/notes.md
+++ b/lecture4/notes.md
@@ -38,7 +38,7 @@ pandoc-latex-environment:
 
 Today, we will see that the nonlinear equations:
 \begin{align*}
-v(s) = \max_{a \in \mathcal{A}(s)} r(s,a) + \sum_{j\in\mathcal{S}} p(j|s,a) v(j) \enspace ,
+v(s) = \max_{a \in \mathcal{A}(s)} r(s,a) + \gamma \sum_{j\in\mathcal{S}} p(j|s,a) v(j) \enspace ,
 \end{align*}
 called the **optimality equations** have a unique solution, and that solution coincides with $v^\star_\gamma$ -- the value of the MDP. In vector notation: 
 \begin{align*}
@@ -146,7 +146,7 @@ L_{d^\star}v_\gamma^\star = r_{d^\star} + \gamma P_{d^\star} v^\star_\gamma = v^
 # Proof
 By the application of Neumann's lemma for policy evaluation(last lecture), we have that for any $d \in \mathcal{D}^{MD}$, $v_{d^\infty, \gamma}$ is the solution to:
 \begin{align*}
-v_{d^\infty, \gamma} = L_{d}v_{d^\infty, \gamma} = r_{d} + \gamma P_{d^\infty, \gamma} = \left( I - \gamma P_d \right)^{-1} r_d \enspace .
+v_{d^\infty, \gamma} = L_{d}v_{d^\infty, \gamma} = r_{d} + \gamma P_d v_{d^\infty, \gamma} = \left( I - \gamma P_d \right)^{-1} r_d \enspace .
 \end{align*}
 
 Going back to our theorem:
@@ -201,7 +201,7 @@ Return:
 
 Theorem 
 
-:   Upon termination of value iteration with the above criterion, the last iterate is within $\epsilon/2$ of the optimal value function, ie: $\|v^{(k+1}) - v^\star_\gamma\| < \epsilon/2$.
+:   Upon termination of value iteration with the above criterion, the last iterate is within $\epsilon/2$ of the optimal value function, ie: $\|v^{(k+1)} - v^\star_\gamma\| < \epsilon/2$.
 
 Proof 
 
@@ -272,7 +272,7 @@ Definition (Jacobian matrix).
 
 Lemma (Chain rule). \label{chain-rule}
 
-:   If $g: \mathbb{R}^k \to \mathbb{R}^n$ is differentiable at $x\in\mathbb{R}^k$ and $f:\mathbb{R}^n \to \mathbb{R}^m$ is differentiable at $g(x)$, then $f \circ g: \mathbb{R}^n \to \mathbb{R}^m$ is differentiable at $x$ and 
+:   If $g: \mathbb{R}^k \to \mathbb{R}^n$ is differentiable at $x\in\mathbb{R}^k$ and $f:\mathbb{R}^n \to \mathbb{R}^m$ is differentiable at $g(x)$, then $f \circ g: \mathbb{R}^k \to \mathbb{R}^m$ is differentiable at $x$ and 
 \begin{align*}
 D(f\circ g)(x) = D f(g(x)) \circ Dg(x) \enspace,
 \end{align*}

--- a/lecture5/notes.md
+++ b/lecture5/notes.md
@@ -69,7 +69,7 @@ Therefore:
 \begin{align*}
 r_{d^{(k+1)}} + \gamma P_{d^{(k+1)}} v^{(k)} \geq r_{d^{(k)}} + \gamma P_{d^{(k)}} v^{(k)} = v^{(k)} \enspace .
 \end{align*}
-where the right-hand side follows from the fact that we found $v^{(k)}$ by solving for $v$ in $(I + \gamma P_{d^{(k)}}) v = r_{d^{(k)}}$.
+where the right-hand side follows from the fact that we found $v^{(k)}$ by solving for $v$ in $(I - \gamma P_{d^{(k)}}) v = r_{d^{(k)}}$.
 
 # Proof
 
@@ -204,7 +204,7 @@ $\| x^{(k+1)} - x^\star \| \leq \lambda \| x^{(k)} - x^\star\|^2$ \enspace .
 
 ::: warning
 
-Newton's method may not be *norm-reducing*, ie it need not be the case that $\|f(x^{(k+1)}) \leq \| f(x^{(k)}\|, \enspace k=0,1,\hdots$
+Newton's method may not be *norm-reducing*, ie it need not be the case that $\|f(x^{(k+1)})\| \leq \| f(x^{(k)}\|, \enspace k=0,1,\hdots$
 
 :::
 

--- a/lecture6/notes.md
+++ b/lecture6/notes.md
@@ -178,7 +178,7 @@ Theorem
 
 # "Modified" Newton-Kantorovich
 
-We can develop a "modifed" counterpart to the above procedure that mimics "modifed policy iteration" where we only take a few terms in the Neumann series expansion. 
+We can develop a "modified" counterpart to the above procedure that mimics "modified policy iteration" where we only take a few terms in the Neumann series expansion. 
 
 - Given $v^{(0)}\in \mathcal{V}, \epsilon > 0$, truncation $n$, initial guess $\tilde{\Delta}_0$
 - Repeat:
@@ -277,7 +277,7 @@ Theorem (6.9.1 in Puterman)
 
 :   Let $d \in \mathcal{D}^{MR}$ and for any $s \in \mathcal{S}$, $a \in \mathcal{A}(s)$, and define: 
 \begin{align*}
-x_d(s,a) \triangleq \sum_{i\in \mathcal{S}} \alpha(i)\sum_{t=1}^\infty \gamma^{(t-1)} P_{d^\infty}(S_t = s, A_t = a | S_1 = i)
+x_d(s,a) \triangleq \sum_{i\in \mathcal{S}} \alpha(i)\sum_{t=1}^\infty \gamma^{t-1} P_{d^\infty}(S_t = s, A_t = a | S_1 = i)
 \end{align*}
 
 1. $x_d$ is a feasible solution to the dual problem
@@ -288,4 +288,4 @@ d_x^\infty(a | s) = \frac{x(s,a)}{\sum_{a'\in \mathcal{A}(s)}x(s,a')}
 
 # Interpretation 
 
-$x(s,a)$ is the total discounted probability joint probability that starting from the initial state $\alpha$, the system is in state $s$ taking action $a$.
+$x(s,a)$ is the total discounted joint probability that starting from the initial state $\alpha$, the system is in state $s$ taking action $a$.

--- a/lecture7/notes.md
+++ b/lecture7/notes.md
@@ -33,7 +33,7 @@ The version of the optimality equations that we used so far was:
 \begin{align*}
 v^\star_\gamma(s) = \max_{a \in \mathcal{A}(s)}\left\{ r(s,a) + \gamma \sum_{j\in\mathcal{S}} p(j|s,a) v^\star_\gamma(j) \right\} \enspace .
 \end{align*}
-Now the same result can also derived over Q-factors/Q-values:
+Now the same result can also be derived over Q-factors/Q-values:
 \begin{align*}
 Q^\star_\gamma(s,a) = r(s,a) + \gamma \sum_{j \in \mathcal{A}(s)} p(j|s,a) \max_{a' \in \mathcal{A}(j)} Q^\star_\gamma(j,a') \enspace .
 \end{align*}
@@ -101,7 +101,7 @@ Theorem (O\&R 12.2.1)
 :   Let $T: \mathcal{V} \to \mathcal{V}$ be a $\gamma$-contraction and $x^\star$ its unique fixed point. Furthermore, let $\{y_k\} \in \mathcal{V}$ be any sequence, and define the local error for $k=0, 1, \hdots$ as $\epsilon_k \triangleq \| T y^{(k)} - y^{(k+1)}\|$. It then holds for $k=0, 1, \hdots$ that: 
 \begin{align*}
 \|y^{(k+1)} - x^\star\| &\leq \frac{1}{1 - \gamma}\left(\gamma \|y^{(k+1)} - y^{(k)}\| + \epsilon_k \right) \\
-\|y^{(k+1)} - x^\star\| &\leq \|x^{(k+1)} - x^\star\| + \sum_{j=0}^k \gamma^{k-j} \epsilon_j + \gamma^{(k+1)}\|x^{(0)} - y^{(0)}\| \, ,
+\|y^{(k+1)} - x^\star\| &\leq \|x^{(k+1)} - x^\star\| + \sum_{j=0}^k \gamma^{k-j} \epsilon_j + \gamma^{k+1}\|x^{(0)} - y^{(0)}\| \, ,
 \end{align*}
 and $\lim_{k\to \infty} y^{(k)} = x^\star$ if and only if $\lim_{k\to\infty} \epsilon_k = 0$ \enspace .
 
@@ -133,7 +133,7 @@ Then the sequence defined by $y^{(k+1)} = \tilde{T}_k y^{(k)}$ converges to the 
 
 12.2.2 provides almost all we need to show convergence of SVI. The argument may look like: 
 
-- Given  $s\in\mathcal{S}$ and $a \in \mathcal{A}(s)$, $F_kQ(s,a)$ converges to $FQ(s,a)$ by the law of large numbers, hence SVI must converge. But...
+- Given  $s\in\mathcal{S}$ and $a \in \mathcal{A}(s)$, $\tilde{F}_kQ(s,a)$ converges to $FQ(s,a)$ by the law of large numbers, hence SVI must converge. But...
 
 ::: warning
 12.2.2 requires $\lim_{k\to\infty} \|\tilde{T}_k x - Tx \| = \sup_{s \in \mathcal{S}}|(\tilde{T}_kx)(s) - (Tx)(s)| = 0$. Therefore, we'd want to not only draw from only **one** conditional $p(\cdot|s,a)$ but for all $s \in \mathcal{S}, a \in \mathcal{A}(s)$ infinitely often. 
@@ -143,8 +143,8 @@ Then the sequence defined by $y^{(k+1)} = \tilde{T}_k y^{(k)}$ converges to the 
 
 Rather than keeping the set of realizations from the conditional $p(\cdot |s,a)$ for each $s \in \mathcal{S}, a \in \mathcal{A}(s)$, we can maintain an online average:
 \begin{align*}
-&Q^{(k+1)}(s, a) = (1 - \eta_k)Q^{(k)}(s,a) + \eta_k (F_k Q^{(k)})(s,a), \enspace s \in \mathcal{S}, a \in \mathcal{A}(s) \\
-&(F_kQ^{(k)})(s,a) = \begin{cases} 
+&Q^{(k+1)}(s, a) = (1 - \eta_k)Q^{(k)}(s,a) + \eta_k (\tilde{F}_k Q^{(k)})(s,a), \enspace s \in \mathcal{S}, a \in \mathcal{A}(s) \\
+&(\tilde{F}_kQ^{(k)})(s,a) = \begin{cases} 
 r(s_t, a_t) + \gamma \max_{a' \in \mathcal{A}(s_t)} Q^{(k)}(s_t, a') & \text{if } (s,a) = (s_t, a_t) \\
 Q^{(k)}(s,a) & \text{otherwise}
 \end{cases}

--- a/lecture8/notes.md
+++ b/lecture8/notes.md
@@ -94,7 +94,7 @@ where we just added and subtracted.
 
 What assumption do we need on the noise term so that it can wash away/average out through time? 
 
-- Commmon assumption: we noise term is a **Martingale**
+- Common assumption: the noise term is a **Martingale**
 
 # Martingale
 
@@ -186,8 +186,8 @@ converges to $x^\star, f(x^\star) = \bar{c}$ under the following assumptions.
 The Q-learning update (tabular) was of the form: 
 
 \begin{align*}
-&Q^{(k+1)}(s, a) = (1 - \eta_k)Q^{(k)}(s,a) + \eta_k (F_k Q^{(k)})(s,a), \enspace s \in \mathcal{S}, a \in \mathcal{A}(s) \\
-&(F_kQ^{(k)})(s,a) = \begin{cases} 
+&Q^{(k+1)}(s, a) = (1 - \eta_k)Q^{(k)}(s,a) + \eta_k (\tilde{F}_k Q^{(k)})(s,a), \enspace s \in \mathcal{S}, a \in \mathcal{A}(s) \\
+&(\tilde{F}_kQ^{(k)})(s,a) = \begin{cases} 
 r(s_t, a_t) + \gamma \max_{a' \in \mathcal{A}(s_t)} Q^{(k)}(s_t, a') & \text{if } (s,a) = (s_t, a_t) \\
 Q^{(k)}(s,a) & \text{otherwise}
 \end{cases}

--- a/lecture9/notes.md
+++ b/lecture9/notes.md
@@ -23,7 +23,7 @@ Tabular TD(0):
   v^{(t+1)}(s_t) = v^{(t)}(s_t) + \eta_t \left(r_t + \gamma v^{(t)}(s_{t+1}) - v^{(t)}(s_t) \right)
   \end{align*}
 
-What does this converge to? We're going to study a more general form an introduce function approximation.
+What does this converge to? We're going to study a more general form and introduce function approximation.
 More specifically, we consider a linear model of the form:
 \begin{align*}
 v(s; w) = \phi(s)^\top w \enspace ,
@@ -41,10 +41,10 @@ Now, we are adding one more layer of approximation: that of approximation of the
 # TD(0) with linear function approximation
 
 \begin{align*}
-w^{(t+1)} = w^{(t)} + \eta_t \left(r_t + \gamma v(s_{t+1}, w^{(t)}) - v(s_t; w^{(t)})\right) \phi_t \enspace.
+w^{(t+1)} = w^{(t)} + \eta_t \left(r_t + \gamma v(s_{t+1}; w^{(t)}) - v(s_t; w^{(t)})\right) \phi_t \enspace.
 \end{align*}
 
-where $\phi_t = \phi(s_t)$. This notational detail is important because it means that also don't have to observe the underlying states directly: only observations of it through the mapping $\phi$ (most likely nonlinear), which also need not be known.
+where $\phi_t = \phi(s_t)$. This notational detail is important because it means that we also don't have to observe the underlying states directly: only observations of it through the mapping $\phi$ (most likely nonlinear), which also need not be known.
 
 # Tabular case
 
@@ -54,7 +54,7 @@ The *tabular* case can be obtained for $\phi(s) \triangleq e_s$: a *one-hot* enc
 
 # Analysis: the ODE approach
 
-Remember the key idea in the ODE approach for the analysis of stochastic approximation algorithms: under the conditions, we can approximate the behavior of algorithm by a continuous-time dynamical system. We obtain his deterministic system by averaging out the noise: by studying the mean iterates. 
+Remember the key idea in the ODE approach for the analysis of stochastic approximation algorithms: under the conditions, we can approximate the behavior of algorithm by a continuous-time dynamical system. We obtain this deterministic system by averaging out the noise: by studying the mean iterates. 
 
 # Underlying stochastic process
 
@@ -98,6 +98,6 @@ Important terms:
 
 Therefore: 
 \begin{align*}
-\Phi^\top X\left( I - \gamma P_d \right) \Phi w - \Phi^\top X r_d   = \mathbb{E}\left[ \phi(S_t) (\phi(S_t)^\top w - \gamma \phi(S_{t+1})^\top w - r(S_t, A_t)\right]
+\Phi^\top X\left( I - \gamma P_d \right) \Phi w - \Phi^\top X r_d   = \mathbb{E}\left[ \phi(S_t) (\phi(S_t)^\top w - \gamma \phi(S_{t+1})^\top w) - r(S_t, A_t)\right]
 \end{align*}
 


### PR DESCRIPTION
Most of the corrections are no brainer. Some might be irrelevant if there was a misunderstanding of the material.